### PR TITLE
Map improvements

### DIFF
--- a/web/modules/custom/nautilus_arcgis_block/assets/arcgis-map.css
+++ b/web/modules/custom/nautilus_arcgis_block/assets/arcgis-map.css
@@ -1,13 +1,6 @@
 .arcgis-map {
-  height: 600px;
-  margin: 0;
-  padding: 0;
-  width: 100%;
+    height: 600px;
+    margin: 0;
+    padding: 0;
+    width: 100%;
 }
-
-#map-legend > div {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.esri-legend__service { border-bottom: none; }

--- a/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
@@ -96,6 +96,7 @@ import {asGraphicsLayer} from './util/layers.js';
         const layerListExpand = new Expand({
             content: layerList,
             expandIcon: 'layers',  // see https://developers.arcgis.com/calcite-design-system/icons/
+            expandTooltip: 'Show Layer List',
             view,
         });
         view.ui.add(layerListExpand, 'top-right');

--- a/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
@@ -3,7 +3,6 @@ import {asGraphicsLayer} from './util/layers.js';
 
 (function ($, Drupal) {
     const MAP_CONTAINER_ID = 'cruise-data-map-container';
-    const MAP_LEGEND_ID = 'map-legend';
     const OET_CRUISES_MASTER_PORTAL_ITEM_ID = '29a7597cb7174df085edd33ac8613a43';
     const ESRI_MODULES = [
         'esri/Basemap',
@@ -100,7 +99,18 @@ import {asGraphicsLayer} from './util/layers.js';
             view,
         });
         view.ui.add(layerListExpand, 'top-right');
-        new Legend({container: document.getElementById(MAP_LEGEND_ID), view});
+
+        const legend = new Legend({
+            container: document.createElement('div'),
+            view,
+        });
+        const legendExpand = new Expand({
+            content: legend,
+            expandIcon: 'legend',
+            expandTooltip: 'Show Legend',
+            view,
+        });
+        view.ui.add(legendExpand, 'top-right');
 
         await webmap.load();
         view.zoom = view.zoom - 1; // zoom out a little to better view all features on load

--- a/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
@@ -1,10 +1,11 @@
+import {asGraphicsLayer} from './util/layers.js';
+
 (function ($, Drupal) {
     const MAP_CONTAINER_ID = 'cruise-data-map-container';
     const MAP_LEGEND_ID = 'map-legend';
     const OET_CRUISES_MASTER_PORTAL_ITEM_ID = '29a7597cb7174df085edd33ac8613a43';
     const ESRI_MODULES = [
         'esri/Basemap',
-        'esri/Graphic',
         'esri/WebMap',
         'esri/layers/FeatureLayer',
         'esri/views/MapView',
@@ -15,28 +16,9 @@
     ];
 
     async function startApp({cruiseName}, modules) {
-        const {Basemap, WebMap, Expand, FeatureLayer, Fullscreen, Graphic, LayerList, Legend, MapView} = modules;
+        const {Basemap, WebMap, Expand, FeatureLayer, Fullscreen, LayerList, Legend, MapView} = modules;
         // Current cruise from Nautilus Live website settings.
         console.log(`Cruise: ${cruiseName} from cruise page context`);
-
-        async function asGraphicsLayer(layer, options = {}) {
-            await layer.load();
-            let query = layer.createQuery();
-            query.where = layer.definitionExpression;
-            const {features, fields, geometryType, spatialReference} = await layer.queryFeatures(query);
-            const graphics = features.map(({attributes, geometry}) => new Graphic({attributes: attributes, geometry}));
-            const graphicsLayer = new FeatureLayer({
-                fields,
-                geometryType,
-                popupTemplate: layer.popupTemplate,
-                renderer: layer.renderer,
-                source: graphics,
-                spatialReference,
-                title: layer.title.replace('OET Cruises master CCOM configured - ', ''),
-                ...options,
-            });
-            return graphicsLayer;
-        }
 
         const shipTrack = await asGraphicsLayer(new FeatureLayer({
             portalItem: {

--- a/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
@@ -97,7 +97,7 @@ import {asGraphicsLayer} from './util/layers.js';
         const layerListExpand = new Expand({
             content: layerList,
             expandIcon: 'layers',  // see https://developers.arcgis.com/calcite-design-system/icons/
-            view: view,
+            view,
         });
         view.ui.add(layerListExpand, 'top-right');
         new Legend({container: document.getElementById(MAP_LEGEND_ID), view});

--- a/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/cruise-data.js
@@ -102,25 +102,15 @@ import {asGraphicsLayer} from './util/layers.js';
     }
 
     Drupal.behaviors.cruiseData = {
-        attach(context, settings) {
+        async attach(context, settings) {
+            const imports = await requireModules(ESRI_MODULES);
             try {
-                require(ESRI_MODULES, function(...imports) {
-                    // Create an object mapping the imports to their module name so that we don't have to keep track
-                    // of load order
-                    const importMapping = imports.reduce((memo, item, idx) => {
-                        const moduleName = ESRI_MODULES[idx].split('/').pop();
-                        memo[moduleName] = item
-                        return memo;
-                    }, {});
-                    (async() => {
-                        const mapRendered = await startApp(settings, importMapping);
+                const mapRendered = await startApp(settings, imports);
                         if (!mapRendered) {
                             $(MAP_CONTAINER_ID).attr('data-drupal-messages', true)
                             const messenger = new Drupal.Message();
                             messenger.add(`No map data available for ${settings.cruiseName}`, {type: 'error'});
                         }
-                    })();
-                });
             } catch (err) {
                 console.error('Failed to start app', err);
             }

--- a/web/modules/custom/nautilus_arcgis_block/assets/util/imports.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/util/imports.js
@@ -1,0 +1,16 @@
+/* global require (dojo.require) */
+
+export async function requireModules(modules) {
+    // Create an object mapping the imports to their module name so that we don't have to keep track
+    // of load order
+    return new Promise(resolve => {
+        require(modules, function(...imports) {
+            const importMapping = imports.reduce((memo, item, idx) => {
+                const moduleName = modules[idx].split('/').pop();
+                memo[moduleName] = item
+                return memo;
+            }, {});
+            resolve(importMapping);
+        });
+    });
+}

--- a/web/modules/custom/nautilus_arcgis_block/assets/util/layers.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/util/layers.js
@@ -1,0 +1,22 @@
+const [Graphic, FeatureLayer] = await new Promise(resolve => {
+    require(['esri/Graphic', 'esri/layers/FeatureLayer'], (...imports) => resolve(imports));
+});
+
+export async function asGraphicsLayer(layer, options = {}) {
+    await layer.load();
+    let query = layer.createQuery();
+    query.where = layer.definitionExpression;
+    const {features, fields, geometryType, spatialReference} = await layer.queryFeatures(query);
+    const graphics = features.map(({attributes, geometry}) => new Graphic({attributes: attributes, geometry}));
+    const graphicsLayer = new FeatureLayer({
+        fields,
+        geometryType,
+        popupTemplate: layer.popupTemplate,
+        renderer: layer.renderer,
+        source: graphics,
+        spatialReference,
+        title: layer.title.replace('OET Cruises master CCOM configured - ', ''),
+        ...options,
+    });
+    return graphicsLayer;
+}

--- a/web/modules/custom/nautilus_arcgis_block/assets/util/layers.js
+++ b/web/modules/custom/nautilus_arcgis_block/assets/util/layers.js
@@ -7,7 +7,7 @@ export async function asGraphicsLayer(layer, options = {}) {
     let query = layer.createQuery();
     query.where = layer.definitionExpression;
     const {features, fields, geometryType, spatialReference} = await layer.queryFeatures(query);
-    const graphics = features.map(({attributes, geometry}) => new Graphic({attributes: attributes, geometry}));
+    const graphics = features.map(({attributes, geometry}) => new Graphic({attributes, geometry}));
     const graphicsLayer = new FeatureLayer({
         fields,
         geometryType,
@@ -18,5 +18,6 @@ export async function asGraphicsLayer(layer, options = {}) {
         title: layer.title.replace('OET Cruises master CCOM configured - ', ''),
         ...options,
     });
+    graphicsLayer.sourceLayer = layer; // store the source layer so the graphicsLayer can be updated as needed
     return graphicsLayer;
 }

--- a/web/modules/custom/nautilus_arcgis_block/nautilus_arcgis_block.libraries.yml
+++ b/web/modules/custom/nautilus_arcgis_block/nautilus_arcgis_block.libraries.yml
@@ -31,7 +31,9 @@ ship-location:
 cruise-data:
   js:
     'assets/cruise-data.js':
-      attributes: {defer: true}
+      attributes:
+        defer: true
+        type: module
       preprocess: false
   dependencies:
     - core/drupal

--- a/web/modules/custom/nautilus_arcgis_block/nautilus_arcgis_block.libraries.yml
+++ b/web/modules/custom/nautilus_arcgis_block/nautilus_arcgis_block.libraries.yml
@@ -17,7 +17,9 @@ common:
 ship-location:
   js:
     'assets/ship-location.js':
-      attributes: {defer: true}
+      attributes:
+        defer: true
+        type: module
       preprocess: false
   dependencies:
     - core/drupal

--- a/web/modules/custom/nautilus_arcgis_block/src/Plugin/Block/CruiseDataMapBlock.php
+++ b/web/modules/custom/nautilus_arcgis_block/src/Plugin/Block/CruiseDataMapBlock.php
@@ -81,11 +81,10 @@ final class CruiseDataMapBlock extends BlockBase {
 
     // Include map container div in block content.
     $build['content'] = [
-      '#markup' => 
+      '#markup' =>
         '<section>
           <div data-drupal-messages></div>
           <div id="cruise-data-map-container" class="arcgis-map"></div>
-          <div id="map-legend"></div>
         </section>',
     ];
 


### PR DESCRIPTION
1. Render layers as graphics layers to prevent multiple requests to server for data and prevent ANY requests to server when interacting with map (pan/zoom). Only need to request data from CCOM server at load and when refreshing/recentering
2. Make cruise summary block map legend togglable and contained in the map